### PR TITLE
Fix Bad Access Crash

### DIFF
--- a/Clock/Clock/Clock-Source/SPClockView.m
+++ b/Clock/Clock/Clock-Source/SPClockView.m
@@ -229,8 +229,10 @@
     
     if (!gregorian) gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     [gregorian setTimeZone:_timeZone]; // Japan
-    NSDateComponents *weekdayComponents =
-    [gregorian components:(NSDayCalendarUnit | NSWeekdayCalendarUnit | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit) fromDate:_time];
+	
+    //	Update Deprecated Method
+    //	Fix crash (deallocated _time variable)
+    NSDateComponents *weekdayComponents = [gregorian components:(NSCalendarUnitDay | NSCalendarUnitWeekday | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond) fromDate:[NSDate date]];
     
     self.hours = [weekdayComponents hour];
     BOOL isDay = (self.hours > 6 && self.hours < 18);


### PR DESCRIPTION
Updated the NSDateComponents variable - replaced the deprecated methods and replaced the _time with [NSDate date]